### PR TITLE
mpsoc: implement PMU configuration object load SiP SVC

### DIFF
--- a/plat/xilinx/zynqmp/pm_service/pm_api_sys.c
+++ b/plat/xilinx/zynqmp/pm_service/pm_api_sys.c
@@ -378,7 +378,10 @@ enum pm_ret_status pm_get_api_version(unsigned int *version)
  */
 enum pm_ret_status pm_set_configuration(unsigned int phys_addr)
 {
-	return PM_RET_ERROR_NOTSUPPORTED;
+	uint32_t payload[PAYLOAD_ARG_CNT];
+
+	PM_PACK_PAYLOAD2(payload, PM_SET_CONFIGURATION, phys_addr);
+	return pm_ipi_send_sync(primary_proc, payload, NULL, 0ma);
 }
 
 /**


### PR DESCRIPTION
I've filled the pm_set_configuration() SiP SVC stub in ATF, that was always returning "PM_RET_ERROR_NOTSUPPORTED". 

I'm using it for loading then PMU configuration object from U-Boot, using SPL instead of FSBL.

This works, but I've concern about security issues, as we are passing to the PMU FW a pointer got from non-secure world without any validation (so I guess we can crash or fool the PMU FW).

So, this PR is mainly to discuss how to handle this..

Currently AFAICT the Xilinx flow does not use ATF to load the PMU configuration object, rather it does this from FSBL (before ATF is even loaded?) directly sending a PMU IPI by itself, so a possible alternative could be drop completely SET_CONFIGURATION SiP SVC from ATF and load the PMU object from SPL before ATF is loaded..

Any thought? :)
