### PR TITLE
xilinx: bl32: A64: accept fdt_addr input parameter

### DIFF
--- a/plat/xilinx/common/plat_startup.c
+++ b/plat/xilinx/common/plat_startup.c
@@ -57,6 +57,7 @@
 struct xfsbl_partition {
 	uint64_t entry_point;
 	uint64_t flags;
+	uint64_t fdt_addr;
 };
 
 /* Structure for handoff parameters to ARM Trusted Firmware (ATF) */
@@ -224,13 +225,16 @@ enum fsbl_handoff fsbl_atf_handover(entry_point_info_t *bl32,
 		if (target_secure == FSBL_FLAGS_SECURE) {
 			image = bl32;
 
-			if (target_estate == FSBL_FLAGS_ESTATE_A32)
+			if (target_estate == FSBL_FLAGS_ESTATE_A32) {
 				bl32->spsr = SPSR_MODE32(MODE32_svc, SPSR_T_ARM,
 							 target_endianness,
 							 DISABLE_ALL_EXCEPTIONS);
-			else
+			} else {
 				bl32->spsr = SPSR_64(MODE_EL1, MODE_SP_ELX,
 						     DISABLE_ALL_EXCEPTIONS);
+				bl32->args.arg3 = ATFHandoffParams->partition[i].fdt_addr;
+				VERBOSE("BL32 fdt: %llx\n", bl32->args.arg3);
+			}
 		} else {
 			image = bl33;
 


### PR DESCRIPTION
Pass the fdt_addr received from SPL to BL32. Since the xfsbl_partition
has been extended, this breaks compatibility with FSBL until the
change is merged.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please see
https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842172/Create+and+Submit+a+Patch
